### PR TITLE
Improve error representation

### DIFF
--- a/attrs_strict/_error.py
+++ b/attrs_strict/_error.py
@@ -1,5 +1,6 @@
 class TypeValidationError(Exception):
-    pass
+    def __repr__(self):
+        return "<{}>".format(str(self))
 
 
 class BadTypeError(TypeValidationError, ValueError):
@@ -9,8 +10,7 @@ class BadTypeError(TypeValidationError, ValueError):
     def add_container(self, container):
         self.containers.append(container)
 
-    def __repr__(self, error):
-        backtrack = ""
+    def _render(self, error):
         if self.containers:
             backtrack = " in ".join(
                 [str(container) for container in self.containers]
@@ -26,7 +26,7 @@ class AttributeTypeError(BadTypeError):
         self.container = container
         self.attribute = attribute
 
-    def __repr__(self):
+    def __str__(self):
         error = "{} must be {} (got {} that is a {})".format(
             self.attribute.name,
             self.attribute.type,
@@ -34,7 +34,7 @@ class AttributeTypeError(BadTypeError):
             type(self.container),
         )
 
-        return super(AttributeTypeError, self).__repr__(error)
+        return self._render(error)
 
 
 class TupleError(BadTypeError):
@@ -44,7 +44,7 @@ class TupleError(BadTypeError):
         self.container = container
         self.tuple_types = tuple_types
 
-    def __repr__(self):
+    def __str__(self):
         error = (
             "Element {} has {} elements than types "
             "specified in {}. Expected {} received {}"
@@ -56,7 +56,7 @@ class TupleError(BadTypeError):
             len(self.container),
         )
 
-        return super(TupleError, self).__repr__(error)
+        return self._render(error)
 
     def _more_or_less(self):
         return "more" if len(self.container) > len(self.tuple_types) else "less"
@@ -69,9 +69,9 @@ class UnionError(BadTypeError):
         self.container = container
         self.expected_type = expected_type
 
-    def __repr__(self):
+    def __str__(self):
         error = "Value of {} {} is not of type {}".format(
             self.attribute, self.container, self.expected_type
         )
 
-        return super(UnionError, self).__repr__(error)
+        return self._render(error)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
     project_urls={
         "Source": "https://github.com/bloomberg/attrs-strict",
         "Tracker": "https://github.com/bloomberg/attrs-strict/issues",
-        "Documentation": "https://github.com/bloomberg/attrs-strict/blob/master/README.md#attrs-runtime-validation",
+        "Documentation": "https://github.com/bloomberg/attrs-strict/blob/"
+        "master/README.md#attrs-runtime-validation",
     },
     classifiers=[
         "Development Status :: 3 - Alpha",
@@ -46,24 +47,23 @@ setup(
         "write_to": "attrs_strict/_version.py",
         "write_to_template": textwrap.dedent(
             """
-            __version__ = {version!r}
-
-            # -----------------------------------------------------------------------------
-            # Copyright 2019 Bloomberg Finance L.P.
-            #
-            # Licensed under the Apache License, Version 2.0 (the "License");
-            # you may not use this file except in compliance with the License.
-            # You may obtain a copy of the License at
-            #
-            #     http://www.apache.org/licenses/LICENSE-2.0
-            #
-            # Unless required by applicable law or agreed to in writing, software
-            # distributed under the License is distributed on an "AS IS" BASIS,
-            # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-            # See the License for the specific language governing permissions and
-            # limitations under the License.
-            # ----------------------------- END-OF-FILE -----------------------------------
-            """
+        __version__ = {version!r}
+    # --------------------------------------------------------------------------
+    # Copyright 2019 Bloomberg Finance L.P.
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    #     http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+    # ----------------------------- END-OF-FILE --------------------------------
+    """
         ).lstrip(),
     },
 )

--- a/tests/test_base_types.py
+++ b/tests/test_base_types.py
@@ -23,7 +23,7 @@ def test_primitive_types(value, expected, actual):
 
     assert repr(
         error.value
-    ) == "number must be {} (got {} that is a {})".format(
+    ) == "<number must be {} (got {} that is a {})>".format(
         expected, value, actual
     )
 
@@ -38,6 +38,6 @@ def test_reassign_evaluate():
         x.number = 5
         attr.validate(x)
 
-    assert repr(error.value) == "number must be {} (got 5 that is a {})".format(
-        str, int
-    )
+    assert repr(
+        error.value
+    ) == "<number must be {} (got 5 that is a {})>".format(str, int)

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -49,7 +49,8 @@ def test_container_is_not_of_expected_type_raises_TypeError(
     with pytest.raises(ValueError) as error:
         validator(None, attr, items)
 
-    assert message == repr(error.value)
+    repr_msg = "<{}>".format(message)
+    assert repr_msg == repr(error.value)
 
 
 def test_does_not_raise_when_container_is_empty_and_allowed():

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -25,9 +25,9 @@ def test_defaultdict_raise_error():
         validator(None, attr, elem)
 
     assert (
-        "foo must be typing.DefaultDict[int, typing.List[str]] "
+        "<foo must be typing.DefaultDict[int, typing.List[str]] "
         "(got 1 that is a {}) in [1, 2, 3] in "
-        "defaultdict({}, {{5: [1, 2, 3]}})"
+        "defaultdict({}, {{5: [1, 2, 3]}})>"
     ).format(int, int) == repr(error.value)
 
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -69,7 +69,8 @@ def test_list_of_values_raise_value_error(values, type_, error_message):
         validator(None, attrib, values)
 
     # THEN
-    assert error_message == repr(error.value)
+    msg = "<{}>".format(error_message)
+    assert msg == repr(error.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tuple.py
+++ b/tests/test_tuple.py
@@ -23,8 +23,8 @@ def test_tuple_with_incorrect_number_of_arguments_raises():
         validator(None, attr, element)
 
     assert (
-        "Element (1, 2, 3, 4) has more elements than types specified "
-        "in typing.Tuple[int, int, int]. Expected 3 received 4"
+        "<Element (1, 2, 3, 4) has more elements than types specified "
+        "in typing.Tuple[int, int, int]. Expected 3 received 4>"
     ) == repr(error.value)
 
 
@@ -41,7 +41,7 @@ def test_tuple_of_tuple_raises():
         validator(None, attr, element)
 
     assert (
-        "Element (3, 4, 5) has more elements than types specified "
+        "<Element (3, 4, 5) has more elements than types specified "
         "in typing.Tuple[typing.Tuple[int, int], typing.Tuple[int, int]]. "
-        "Expected 2 received 3 in ((1, 2), (3, 4, 5))"
+        "Expected 2 received 3 in ((1, 2), (3, 4, 5))>"
     ) == repr(error.value)

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -39,7 +39,8 @@ def test_union_when_type_is_not_specified_raises(element, type_, error_message):
     with pytest.raises(ValueError) as error:
         validator(None, attr, element)
 
-    assert error_message == repr(error.value)
+    repr_msg = "<{}>".format(error_message)
+    assert repr_msg == repr(error.value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
1. Do not override the object models interface inside BadTypeError
2. Adhere to repr representation idiom of using <> as wrapper text
3. Implement __str__ rather than __repr__

