### PR TITLE
Set fail_on_warning false

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,7 @@ version: 2
 sphinx:
   builder: html
   configuration: doc/conf.py
-  fail_on_warning: true
+  fail_on_warning: false
 formats: all
 python:
    version: 3.7


### PR DESCRIPTION
Fixes 
```
Warning, treated as error:
unknown mimetype for .nojekyll, ignoring
```