### PR TITLE
Correct Travis-CI deployment condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ deploy:
     on:
       tags: true
       python: "3.7"
-      condition: -n "$PYPI_PASSWORD"
+      condition: -n "$TWINE_PASSWORD"


### PR DESCRIPTION
The deployment configuration in Travis-CI is now supplying TWINE_PASSWORD,
not PYPI_PASSWORD, so the condition check should test that variable.

Signed-off-by: Kevin P. Fleming <kpfleming@bloomberg.net>