### PR TITLE
add annotations and py.typed

### DIFF
--- a/attrs_strict/_error.py
+++ b/attrs_strict/_error.py
@@ -1,16 +1,22 @@
+import typing
+
+if typing.TYPE_CHECKING:
+    import attr
+
+
 class TypeValidationError(Exception):
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<{}>".format(str(self))
 
 
 class BadTypeError(TypeValidationError, ValueError):
-    def __init__(self):
-        self.containers = []
+    def __init__(self) -> None:
+        self.containers: typing.List[typing.Any] = []
 
-    def add_container(self, container):
+    def add_container(self, container: typing.Any) -> None:
         self.containers.append(container)
 
-    def _render(self, error):
+    def _render(self, error: str) -> str:
         if self.containers:
             backtrack = " in ".join(
                 [str(container) for container in self.containers]
@@ -21,12 +27,14 @@ class BadTypeError(TypeValidationError, ValueError):
 
 
 class AttributeTypeError(BadTypeError):
-    def __init__(self, container, attribute):
+    def __init__(
+        self, container: typing.Any, attribute: attr.Attribute
+    ) -> None:
         super(AttributeTypeError, self).__init__()
         self.container = container
         self.attribute = attribute
 
-    def __str__(self):
+    def __str__(self) -> str:
         error = "{} must be {} (got {} that is a {})".format(
             self.attribute.name,
             self.attribute.type,
@@ -38,29 +46,32 @@ class AttributeTypeError(BadTypeError):
 
 
 class EmptyError(BadTypeError):
-    def __init__(self, container, attribute):
+    def __init__(self, container: typing.Any, attribute: attr.Attribute):
         super(EmptyError, self).__init__()
         self.container = container
         self.attribute = attribute
 
-    def __str__(self):
+    def __str__(self) -> str:
         error = "{} can not be empty and must be {} (got {})".format(
-            self.attribute.name,
-            self.attribute.type,
-            self.container,
+            self.attribute.name, self.attribute.type, self.container
         )
 
         return self._render(error)
 
 
 class TupleError(BadTypeError):
-    def __init__(self, container, attribute, tuple_types):
+    def __init__(
+        self,
+        container: typing.Any,
+        attribute: typing.Optional[typing.Type],
+        tuple_types: typing.Tuple[typing.Type],
+    ):
         super(TupleError, self).__init__()
         self.attribute = attribute
         self.container = container
         self.tuple_types = tuple_types
 
-    def __str__(self):
+    def __str__(self) -> str:
         error = (
             "Element {} has {} elements than types "
             "specified in {}. Expected {} received {}"
@@ -74,18 +85,23 @@ class TupleError(BadTypeError):
 
         return self._render(error)
 
-    def _more_or_less(self):
+    def _more_or_less(self) -> str:
         return "more" if len(self.container) > len(self.tuple_types) else "less"
 
 
 class UnionError(BadTypeError):
-    def __init__(self, container, attribute, expected_type):
+    def __init__(
+        self,
+        container: typing.Any,
+        attribute: str,
+        expected_type: typing.Optional[typing.Type],
+    ) -> None:
         super(UnionError, self).__init__()
         self.attribute = attribute
         self.container = container
         self.expected_type = expected_type
 
-    def __str__(self):
+    def __str__(self) -> str:
         error = "Value of {} {} is not of type {}".format(
             self.attribute, self.container, self.expected_type
         )

--- a/attrs_strict/_error.py
+++ b/attrs_strict/_error.py
@@ -1,7 +1,5 @@
 import typing
-
-if typing.TYPE_CHECKING:
-    import attr
+import attr
 
 
 class TypeValidationError(Exception):

--- a/attrs_strict/_type_validation.py
+++ b/attrs_strict/_type_validation.py
@@ -1,7 +1,7 @@
-from __future__ import annotations
-
 import collections
 import typing
+
+import attr
 
 from ._error import (
     AttributeTypeError,
@@ -11,13 +11,10 @@ from ._error import (
     UnionError,
 )
 
-if typing.TYPE_CHECKING:
-    import attr
-
 
 def type_validator(
     empty_ok: bool = True,
-) -> typing.Callable[[typing.Any, attr.Attribute, typing.Any], None]:
+) -> typing.Callable[[typing.Any, "attr.Attribute", typing.Any], None]:
     """
     Validates the attributes using the type argument specified. If the
     type argument is not present, the attribute is considered valid.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,12 @@
 [bdist_wheel]
 universal = true
+
+[mypy]
+python_version = 3.7
+namespace_packages=True
+
+warn_unused_configs = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+disallow_untyped_defs = True
+strict_equality = True


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #24

**Describe your changes**
made `attrs-strict` PEP561 compatible by adding annotations and `py.typed`

**Testing performed**
Was able to successfully run static type checking in a test project after installing `attrs-strict` from my branch.

**Additional context**
Unsure how to add type checking to CI when Tox is involved. Could use some guidance on that.