### PR TITLE
Remove basepython from the publish section of tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,6 @@ commands = python -m pep517.build -s -b . -o {envtmpdir}
 [testenv:pypi_publish]
 changedir = {toxinidir}
 description = Upload a new package to pypi
-basepython = python3.7
 deps = twine >= 1.12.1
        pep517
 passenv = TWINE_PASSWORD https_proxy no_proxy


### PR DESCRIPTION
This is making Travis fail because the interpreter used is
Python3.8

Signed-off-by: Erik-Cristian Seulean <eseulean@bloomberg.net>
