### PR TITLE
Fix handlying of typing.Any

### DIFF
--- a/attrs_strict/_error.py
+++ b/attrs_strict/_error.py
@@ -45,9 +45,7 @@ class EmptyError(BadTypeError):
 
     def __str__(self):
         error = "{} can not be empty and must be {} (got {})".format(
-            self.attribute.name,
-            self.attribute.type,
-            self.container,
+            self.attribute.name, self.attribute.type, self.container,
         )
 
         return self._render(error)

--- a/attrs_strict/_type_validation.py
+++ b/attrs_strict/_type_validation.py
@@ -1,7 +1,13 @@
 import collections
 import typing
 
-from ._error import AttributeTypeError, BadTypeError, EmptyError, TupleError, UnionError
+from ._error import (
+    AttributeTypeError,
+    BadTypeError,
+    EmptyError,
+    TupleError,
+    UnionError,
+)
 
 
 def type_validator(empty_ok=True):
@@ -54,7 +60,7 @@ def _validate_elements(attribute, value, expected_type):
 
 
 def _handle_set_or_list(attribute, container, expected_type):
-    element_type, = expected_type.__args__
+    (element_type,) = expected_type.__args__
 
     for element in container:
         try:

--- a/attrs_strict/_type_validation.py
+++ b/attrs_strict/_type_validation.py
@@ -37,7 +37,7 @@ def _validate_elements(attribute, value, expected_type):
         else expected_type
     )
 
-    if base_type is None:
+    if base_type is None or base_type == typing.Any:
         return
 
     if base_type != typing.Union and not isinstance(value, base_type):

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -1,5 +1,5 @@
 import collections
-from typing import DefaultDict, List
+from typing import Any, Dict, DefaultDict, List
 
 import pytest
 
@@ -41,5 +41,17 @@ def test_defaultdict_with_correct_type_no_raise():
     attr = MagicMock()
     attr.name = "foo"
     attr.type = DefaultDict[int, List[int]]
+
+    validator(None, attr, elem)
+
+
+def test_dict_with_any_does_not_raise():
+    elem = {"foo": 123, "b": "abc"}
+
+    validator = type_validator()
+
+    attr = MagicMock()
+    attr.name = "zoo"
+    attr.type = Dict[str, Any]
 
     validator(None, attr, elem)

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Set, Tuple
+from typing import Any, Dict, List, Set, Tuple
 
 import pytest
 
@@ -80,6 +80,8 @@ def test_list_of_values_raise_value_error(values, type_, error_message):
         ([[1], [2], [3]], List[List[int]]),
         ({1, 2, 3}, Set[int]),
         ([{1: [1, 2, 3], 2: [3, 4, 5]}], List[Dict[int, List[int]]]),
+        ([1, 2, 3, 4], List[Any]),
+        ([1, 2, {"foo": "bar"}], List[Any]),
     ],
 )
 def test_list_of_valid_values_no_raise(values, type_):


### PR DESCRIPTION
So far Any was not taken in consideration and it was failing
to handle it correctly. If the base_type is Any, stop the
recursive check and return as if everything is fine.

Signed-off-by: Erik-Cristian Seulean <eseulean@bloomberg.net>

*Issue number of the reported bug or feature request: #27 

