### PR TITLE
Add support for Mapping and MutableMapping

### DIFF
--- a/attrs_strict/_type_validation.py
+++ b/attrs_strict/_type_validation.py
@@ -9,6 +9,13 @@ from ._error import (
     UnionError,
 )
 
+try:
+    from collections.abc import Mapping
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import Mapping
+    from collections import MutableMapping
+
 
 def type_validator(empty_ok=True):
     """
@@ -49,8 +56,12 @@ def _validate_elements(attribute, value, expected_type):
         dict,
         collections.OrderedDict,
         collections.defaultdict,
+        Mapping,
+        MutableMapping,
         typing.Dict,
         typing.DefaultDict,
+        typing.Mapping,
+        typing.MutableMapping,
     }:
         _handle_dict(attribute, value, expected_type)
     elif base_type in {tuple, typing.Tuple}:

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -1,9 +1,17 @@
 import collections
-from typing import Any, Dict, DefaultDict, List
+from typing import Any, DefaultDict, Dict, List, Mapping, MutableMapping
 
 import pytest
 
 from attrs_strict import type_validator
+
+try:
+    from collections.abc import Mapping as CollectionsMapping
+    from collections.abc import MutableMapping as CollectionsMutableMapping
+except ImportError:
+    from collections import Mapping as CollectionsMapping
+    from collections import MutableMapping as CollectionsMutableMapping
+
 
 try:
     from unittest.mock import MagicMock
@@ -55,3 +63,60 @@ def test_dict_with_any_does_not_raise():
     attr.type = Dict[str, Any]
 
     validator(None, attr, elem)
+
+
+@pytest.mark.parametrize(
+    "data, type, validator_type, error_message",
+    [
+        (
+            {"foo": 123},
+            CollectionsMapping,
+            Mapping,
+            (
+                "<zoo must be typing.Mapping[str, str] "
+                "(got 123 that is a {})"
+            ).format(int),
+        ),
+        (
+            {1: "boo", 2: "zoo"},
+            CollectionsMutableMapping,
+            MutableMapping,
+            (
+                "<zoo must be typing.MutableMapping[str, str] "
+                "(got 1 that is a {})"
+            ).format(int),
+        ),
+    ],
+)
+def test_abc_mapping_types_throw_when_type_is_wrong(
+    data, type, validator_type, error_message
+):
+    class TestMapping(type):
+        def __init__(self, items):
+            self._data = items
+
+        def __getitem__(self, item):
+            return self._data[item]
+
+        def __len__(self):
+            return len(self._data)
+
+        def __iter__(self):
+            return iter(self._data)
+
+        def __delitem__(self, item):
+            pass
+
+        def __setitem__(self, item, value):
+            pass
+
+    validator = type_validator()
+
+    attr = MagicMock()
+    attr.name = "zoo"
+    attr.type = validator_type[str, str]
+
+    with pytest.raises(ValueError) as error:
+        validator(None, attr, TestMapping(data))
+
+    assert error_message in repr(error.value)


### PR DESCRIPTION
This would enable custom made types that extend
collections.abc.Mapping and collections.abc.MutableMapping

Signed-off-by: Erik-Cristian Seulean <eseulean@bloomberg.net>

Issue number of the reported bug or feature request: #27
