### PR TITLE
Newtype support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ attrs_strict._error.AttributeTypeError: names must be
 
 ### What is currently supported ?
 
-Currently there's support for simple types and types specified in the `typing` module: `List`, `Dict`, `DefaultDict`, `Set`, `Union`, `Tuple` and any combination of them. This means that you can specify nested types like `List[List[Dict[int, str]]]` and the validation would check if attribute has the specific type.
+Currently there's support for simple types and types specified in the `typing` module: `List`, `Dict`, `DefaultDict`, `Set`, `Union`, `Tuple`, `NewType`, and any combination of them. This means that you can specify nested types like `List[List[Dict[int, str]]]` and the validation would check if attribute has the specific type.
 
 `Callables`, `TypeVars` or `Generics` are not supported yet but there are plans to support this in the future.
 

--- a/attrs_strict/_commons.py
+++ b/attrs_strict/_commons.py
@@ -1,0 +1,13 @@
+def is_newtype(type_):
+    return (
+        hasattr(type_, "__name__")
+        and type_.__module__ == "typing"
+        and type_.__name__ == "SomeNew"
+    )
+
+
+def format_type(type_):
+    if is_newtype(type_):
+        return "NewType({}, {})".format(type_.__name__, type_.__supertype__)
+
+    return str(type_)

--- a/attrs_strict/_error.py
+++ b/attrs_strict/_error.py
@@ -1,3 +1,6 @@
+from ._commons import format_type
+
+
 class TypeValidationError(Exception):
     def __repr__(self):
         return "<{}>".format(str(self))
@@ -29,7 +32,7 @@ class AttributeTypeError(BadTypeError):
     def __str__(self):
         error = "{} must be {} (got {} that is a {})".format(
             self.attribute.name,
-            self.attribute.type,
+            format_type(self.attribute.type),
             self.container,
             type(self.container),
         )
@@ -45,7 +48,9 @@ class EmptyError(BadTypeError):
 
     def __str__(self):
         error = "{} can not be empty and must be {} (got {})".format(
-            self.attribute.name, self.attribute.type, self.container,
+            self.attribute.name,
+            format_type(self.attribute.type),
+            self.container,
         )
 
         return self._render(error)

--- a/attrs_strict/_type_validation.py
+++ b/attrs_strict/_type_validation.py
@@ -1,6 +1,7 @@
 import collections
 import typing
 
+from ._commons import is_newtype
 from ._error import (
     AttributeTypeError,
     BadTypeError,
@@ -53,12 +54,15 @@ def type_validator(empty_ok=True):
 
 
 def _validate_elements(attribute, value, expected_type):
-    base_type = (
-        expected_type.__origin__
-        if hasattr(expected_type, "__origin__")
+    if (
+        hasattr(expected_type, "__origin__")
         and expected_type.__origin__ is not None
-        else expected_type
-    )
+    ):
+        base_type = expected_type.__origin__
+    elif is_newtype(expected_type):
+        base_type = expected_type.__supertype__
+    else:
+        base_type = expected_type
 
     if base_type is None or base_type == typing.Any:
         return

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -78,9 +78,9 @@ What is currently supported ?
 
 Currently there's support for builtin types and types specified in the :code:`typing`
 module: :code:`List`, :code:`Dict`, :code:`DefaultDict`, :code:`Set`, :code:`Union`,
-:code:`Tuple` and any combination of them. This means that you can specify nested
-types like  :code:`List[List[Dict[int, str]]]` and the validation would check if
-attribute has the specific type.
+:code:`Tuple`, :code:`NewType` and any combination of them. This means that you can
+specify nested types like :code:`List[List[Dict[int, str]]]` and the validation would
+check if attribute has the specific type.
 
 :code:`Callables`, :code:`TypeVars` or :code:`Generics` are not supported yet but
 there are plans to support this in the future.

--- a/tests/test_newtype.py
+++ b/tests/test_newtype.py
@@ -1,0 +1,104 @@
+import typing
+
+import pytest
+
+from attrs_strict import AttributeTypeError, BadTypeError, type_validator
+
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import Mock as MagicMock
+
+
+@pytest.mark.parametrize("test_type, correct", [(str, "foo"), (int, 42),])
+def test_typing_newtype_single_validation_success(test_type, correct):
+    SomeNew = typing.NewType("SomeNew", test_type)
+
+    validator = type_validator()
+    attr = MagicMock()
+    attr.type = SomeNew
+
+    validator(None, attr, correct)
+    validator(None, attr, SomeNew(correct))
+
+
+@pytest.mark.parametrize(
+    "test_type, wrongs", [(str, [42, True]), (int, ["foo", ()]),]
+)
+def test_typing_newtype_single_validation_failure(test_type, wrongs):
+    SomeNew = typing.NewType("SomeNew", test_type)
+
+    validator = type_validator()
+    attr = MagicMock()
+    attr.type = SomeNew
+
+    for wrong in wrongs:
+        with pytest.raises(AttributeTypeError) as error:
+            validator(None, attr, wrong)
+
+    assert "must be NewType(SomeNew, {})".format(str(test_type)) in str(
+        error.value
+    )
+
+
+@pytest.mark.parametrize(
+    "container, test_type, correct",
+    [
+        (typing.List, str, ["foo", "bar"]),
+        (typing.Tuple, int, (0,)),
+        (typing.Optional, str, None),
+    ],
+)
+def test_typing_newtype_within_container_validation_success(
+    container, test_type, correct
+):
+    SomeNew = typing.NewType("SomeNew", test_type)
+
+    validator = type_validator()
+    attr = MagicMock()
+    attr.type = container[SomeNew]
+
+    validator(None, attr, correct)
+
+
+@pytest.mark.parametrize(
+    "container, test_type, wrongs",
+    [
+        (typing.List, str, [42, True, "foo", ("foo", "bar")]),
+        (typing.Tuple, int, ["foo", 42, [0, 1, "2"]]),
+        (typing.Optional, str, [42, (1, 2)]),
+    ],
+)
+def test_typing_newtype_within_container_validation_failure(
+    container, test_type, wrongs
+):
+    SomeNew = typing.NewType("SomeNew", test_type)
+
+    validator = type_validator()
+    attr = MagicMock()
+    attr.type = container[SomeNew]
+
+    for wrong in wrongs:
+        with pytest.raises(BadTypeError) as error:
+            validator(None, attr, wrong)
+
+    assert "must be {}".format(str(attr.type)) in str(
+        error.value
+    ) or "is not of type {}".format(str(attr.type)) in str(error.value)
+
+
+# -----------------------------------------------------------------------------
+# Copyright 2019 Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------- END-OF-FILE -----------------------------------


### PR DESCRIPTION
This PR adds support for [NewType](https://docs.python.org/3.6/library/typing.html?highlight=newtype#typing.NewType) in the typing library. For example

    UserName = NewType('UserName', str)

NewType intended to be an alias for another type. It can be used only in type checkers (e.g. mypy). During instance execution, it dereference to its alias, that means it is *not* a new type (internally it is just a function). Hence, it is not possible to check for a new type, just for its alias. This is exactly what I do in the MR, I dereference its alias (str in example), and just check for the alias (similar to `__origin__` as it is expected during instance execution. 

Tests are added to check some example NewType aliases if the validation succeeds or not.

I also added a pretty type printer to the errors. The `__str__` of a NewType is always
`NewType.<locals>.new_type`, so it includes neither its custom name ('UserName') nor
the type for which it is an alias ('str'), which is not very helpful to
identify why a certain type check failed. Hence, such information
are also printed in error messages, but other types are left as they
were before.