### PR TITLE
Fix `is_newtype()` check

### DIFF
--- a/attrs_strict/_commons.py
+++ b/attrs_strict/_commons.py
@@ -1,8 +1,8 @@
 def is_newtype(type_):
     return (
         hasattr(type_, "__name__")
+        and hasattr(type_, "__supertype__")
         and type_.__module__ == "typing"
-        and type_.__name__ == "SomeNew"
     )
 
 


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #35

**Describe your changes**
Changed `is_newtype()` to check for existence of  `__supertype__` .

I couldn't find a documented way to check for `isinstance(_, NewType)`. After looking at the [implementation](https://github.com/python/typing/blob/08a537d484edddb563288982f8073d241fec5535/typing_extensions/src_py3/typing_extensions.py#L1030-L1054), this should be enough. 

