### PR TITLE
Upgrade packaging to new standards

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 19.3b0
+    rev: 19.10b0
     hooks:
     -   id: black
         args: [--safe]
-        language_version: python3.7
+        language_version: python3.8
 -   repo: https://github.com/asottile/blacken-docs
-    rev: v1.3.0
+    rev: v1.7.0
     hooks:
     -   id: blacken-docs
         args: [--skip-errors]
         additional_dependencies: [black==19.3b0]
         language_version: python3.7
 -   repo: https://github.com/asottile/seed-isort-config
-    rev: v1.9.2
+    rev: v2.1.1
     hooks:
     -   id: seed-isort-config
         args: [--application-directories, "src:."]
@@ -22,20 +22,27 @@ repos:
     hooks:
     -   id: isort
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+    rev: v3.1.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: debug-statements
-    -   id: flake8
-        additional_dependencies: ["flake8-bugbear == 19.8.0"]
-        language_version: python3.7
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.8.2
+  hooks:
+  - id: flake8
+    additional_dependencies: ["flake8-bugbear == 20.1.2"]
+    language_version: python3.8
+- repo: https://github.com/asottile/setup-cfg-fmt
+  rev: v1.9.0
+  hooks:
+  - id: setup-cfg-fmt
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v1.24.0
+    rev: v2.4.4
     hooks:
     -   id: pyupgrade
 -   repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.4.1
+    rev: v1.5.1
     hooks:
     -   id: rst-backticks

--- a/attrs_strict/_type_validation.py
+++ b/attrs_strict/_type_validation.py
@@ -171,7 +171,7 @@ def _handle_tuple(attribute, container, expected_type):
     tuple_types = expected_type.__args__
     if len(tuple_types) == 2 and tuple_types[1] == Ellipsis:
         element_type = tuple_types[0]
-        tuple_types = (element_type, ) * len(container)
+        tuple_types = (element_type,) * len(container)
 
     if len(container) != len(tuple_types):
         raise TupleError(container, attribute.type, tuple_types)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,34 @@
 [build-system]
 requires = [
-    "setuptools >= 40.0.4",
-    "setuptools_scm >= 2.0.0, <4",
-    "wheel >= 0.29.0",
+    "setuptools >= 44",
+    "wheel >= 0.30",
+    "setuptools_scm[toml]>=3.4",
 ]
 build-backend = 'setuptools.build_meta'
 
 [tool.black]
 line-length = 80
+
+[tool.setuptools_scm]
+write_to = "attrs_strict/_version.py"
+write_to_template = """
+\"\"\" Version information \"\"\"
+
+__version__ = "{version}"
+
+# -----------------------------------------------------------------------------
+# Copyright 2019 Bloomberg Finance L.P.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------- END-OF-FILE -----------------------------------
+"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,45 @@
+[metadata]
+name = attrs_strict
+description = Runtime validators for attrs
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/bloomberg/attrs-strict
+author = Erik-Cristian Seulean
+author_email = eseulean@bloomberg.net
+license = Apache-2.0
+license_file = LICENSE
+classifiers =
+    Development Status :: 3 - Alpha
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Operating System :: MacOS :: MacOS X
+    Operating System :: Microsoft :: Windows
+    Operating System :: POSIX
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
+    Topic :: Software Development :: Libraries
+    Topic :: Software Development :: Testing
+    Topic :: Utilities
+project_urls =
+    Source=https://github.com/bloomberg/attrs-strict
+    Tracker=https://github.com/bloomberg/attrs-strict/issues
+    Documentation=https://github.com/bloomberg/attrs-strict/blob/master/README.md#attrs-runtime-validation
+
+[options]
+packages = attrs_strict
+install_requires =
+    attrs
+    typing;python_version<'3.5'
+python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4
+tests_require =
+    mock;python_version<'3.3'
+    pytest >= 4
+
 [bdist_wheel]
 universal = true

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-import textwrap
-
 from setuptools import setup
 
 with open("README.md") as fp:
@@ -13,81 +11,4 @@ long_description = "".join(
     ]
 )
 
-setup(
-    name="attrs-strict",
-    description="Runtime validators for attrs",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author="Erik-Cristian Seulean",
-    author_email="eseulean@bloomberg.net",
-    license="Apache 2.0",
-    packages=["attrs_strict"],
-    install_requires=["attrs", "typing; python_version<'3.5'"],
-    tests_require=["mock", "pytest"],
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
-    url="https://github.com/bloomberg/attrs-strict",
-    project_urls={
-        "Source": "https://github.com/bloomberg/attrs-strict",
-        "Tracker": "https://github.com/bloomberg/attrs-strict/issues",
-        "Documentation": "https://github.com/bloomberg/attrs-strict/blob/"
-        "master/README.md#attrs-runtime-validation",
-    },
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: POSIX",
-        "Operating System :: Microsoft :: Windows",
-        "Operating System :: MacOS :: MacOS X",
-        "Topic :: Software Development :: Testing",
-        "Topic :: Software Development :: Libraries",
-        "Topic :: Utilities",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-    ],
-    use_scm_version={
-        "write_to": "attrs_strict/_version.py",
-        "write_to_template": textwrap.dedent(
-            """
-        __version__ = {version!r}
-    # --------------------------------------------------------------------------
-    # Copyright 2019 Bloomberg Finance L.P.
-    #
-    # Licensed under the Apache License, Version 2.0 (the "License");
-    # you may not use this file except in compliance with the License.
-    # You may obtain a copy of the License at
-    #
-    #     http://www.apache.org/licenses/LICENSE-2.0
-    #
-    # Unless required by applicable law or agreed to in writing, software
-    # distributed under the License is distributed on an "AS IS" BASIS,
-    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    # See the License for the specific language governing permissions and
-    # limitations under the License.
-    # ----------------------------- END-OF-FILE --------------------------------
-    """
-        ).lstrip(),
-    },
-)
-
-# -----------------------------------------------------------------------------
-# Copyright 2019 Bloomberg Finance L.P.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# ----------------------------- END-OF-FILE -----------------------------------
+setup(long_description=long_description)

--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ passenv = {[testenv]passenv}
           # without PROGRAMDATA cloning using git for Windows will fail with an
           # `error setting certificate verify locations` error
           PROGRAMDATA
-deps = pre-commit >= 1.14.4, < 2
+deps = pre-commit >= 2
 skip_install = True
 commands = pre-commit run --all-files --show-diff-on-failure
            python -c 'import pathlib; print("hint: run \{\} install to add checks as pre-commit hook".format(pathlib.Path(r"{envdir}") / "bin" / "pre-commit"))'


### PR DESCRIPTION
- Declarative setuptools over imperative.
- Bump linters/formatters to newer versions.
- Explicitly disallow python3.5 support as we don't test for it.