### PR TITLE
Support string annotations

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,5 @@
+import sys
+
+
+def pytest_ignore_collect(path):
+    return sys.version_info[0] <= 2 and str(path).endswith("__py3.py")

--- a/src/attrs_strict/_type_validation.pyi
+++ b/src/attrs_strict/_type_validation.pyi
@@ -1,6 +1,11 @@
 import typing
 import attr
 
+def resolve_types(
+    cls: type,
+    global_ns: typing.Optional[typing.Dict[str, typing.Any]] = None,
+    local_ns: typing.Optional[typing.Dict[str, typing.Any]] = None,
+) -> None: ...
 def type_validator(
     empty_ok: bool = True,
 ) -> typing.Callable[

--- a/tests/test_auto_attribs__py3.py
+++ b/tests/test_auto_attribs__py3.py
@@ -1,0 +1,54 @@
+from typing import Optional
+
+import attr
+import pytest
+
+from attrs_strict import type_validator
+
+
+@pytest.mark.parametrize(
+    "type_, good_value, bad_value",
+    [(str, "str", 0xBAD), (int, 7, "bad"), (Optional[str], None, 0xBAD)],
+)
+def test_real_types(type_, good_value, bad_value):
+    @attr.s(auto_attribs=True)
+    class Something:
+        value: type_ = attr.ib(validator=type_validator())
+
+    with pytest.raises(ValueError):
+        Something(bad_value)
+
+    x = Something(good_value)
+    with pytest.raises(ValueError):
+        x.value = bad_value
+        attr.validate(x)
+
+
+@attr.s(auto_attribs=True)
+class Child:
+    parent: "Parent" = attr.ib(validator=type_validator())
+
+
+@attr.s(auto_attribs=True)
+class Parent:
+    pass
+
+
+def test_forward_ref():
+    Child(Parent())
+
+    with pytest.raises(ValueError):
+        Child(15)
+
+
+@attr.s(auto_attribs=True)
+class Self:
+    parent: Optional["Self"] = attr.ib(None, validator=type_validator())
+
+
+def test_recursive():
+    Self(Self())
+    Self(Self(None))
+
+    with pytest.raises(ValueError):
+        Self(Self(17))

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ commands = pytest \
            --cov-config "{toxinidir}/tox.ini" \
            --junitxml {toxworkdir}/junit.{envname}.xml \
            {posargs:tests}
+rsyncdirs = conftest.py
 
 [testenv:type]
 description = try to merge our types against our source


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #45*

**Describe your changes**
* Wrote tests for attr.s(auto_attribs=True) 
* Made these tests only run on python 3.
* Wrote tests for classes with string annotations and Forward References.
* Added a new method `resolve_types` which uses get_type_hints to overwrite the field.type to a fully resolved type.
* For performance reasons, the resolving only triggers when you hit a string annotation or a ForwardRef.  

**Testing performed**
Unit tests.  Ran on a couple of classes too.

**Additional context**
None
