### PR TITLE
Added funcsigs>=1.0.2 for python_version<3.5

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,13 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
-    - name: set PY
-      run: echo "::set-env name=PY::$(python -c 'import hashlib, sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
-    - uses: actions/cache@v2
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-    - uses: pre-commit/action@v1.1.0
+    - uses: pre-commit/action@v2.0.0
 
   test:
     name: ${{ matrix.py }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ project_urls =
 packages = attrs_strict
 install_requires =
     attrs>=19.1.0
+    funcsigs>=1.0.2;python_version<'3.5'
     typing>=3.7.4.1;python_version<'3.5'
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4
 package_dir =


### PR DESCRIPTION
#49 

**Describe your changes**
Added funcsigs package to setup.cfg, to be required when installing `attrs-strict` from python<3.5.

**Testing performed**
Ran the package in Python2.7 and in Python3.4 with funcsigs installed.


**additional context**
Even though Python 2.7.18 introduced `inspect` in the standard library it lacks the `signature` function used in this package.