### PR TITLE
Fix some `Callable` false positives

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,7 +22,6 @@ extensions = [
 ]
 
 templates_path = ["_templates"]
-language = "python"
 
 exclude_patterns = []
 

--- a/src/attrs_strict/_error.pyi
+++ b/src/attrs_strict/_error.pyi
@@ -24,8 +24,8 @@ class CallableError(BadTypeError):
         attribute: attr.Attribute[typing.Any],
         callable_signature: inspect.Signature,
         expected_signature: typing.Type[typing.Callable[..., typing.Any]],
-        mismatch_callable_arg: inspect.Parameter,
-        expected_callable_arg: inspect.Parameter,
+        mismatch_callable_arg: typing.Type[typing.Any],
+        expected_callable_arg: typing.Type[typing.Any],
     ) -> None: ...
     def __str__(self) -> str: ...
 

--- a/src/attrs_strict/_type_validation.py
+++ b/src/attrs_strict/_type_validation.py
@@ -155,6 +155,7 @@ def _get_base_type(type_):
 def _type_matching(actual, expected):
     actual = actual.__supertype__ if is_newtype(actual) else actual
     expected = expected.__supertype__ if is_newtype(expected) else expected
+    actual = type(None) if actual is None else actual
 
     if expected == actual or expected == typing.Any:
         return True

--- a/src/attrs_strict/_type_validation.py
+++ b/src/attrs_strict/_type_validation.py
@@ -201,7 +201,8 @@ def _handle_callable(attribute, callable_, expected_type):
     if not getattr(expected_type, "__args__", None):
         return  # No annotations specified on type, matches all Callables
 
-    *expected_args, expected_return = expected_type.__args__  # type: ignore
+    expected_args = expected_type.__args__[:-1]  # type: ignore
+    expected_return = expected_type.__args__[-1]  # type: ignore
     for callable_arg, expected_arg in zip_longest(callable_args, expected_args):
         callable_type = (
             empty if callable_arg is None else callable_arg.annotation

--- a/src/attrs_strict/_type_validation.pyi
+++ b/src/attrs_strict/_type_validation.pyi
@@ -1,3 +1,4 @@
+import inspect
 import sys
 import typing
 
@@ -32,6 +33,13 @@ def _get_base_type(
     type_: typing.Type[typing.Any],
 ) -> typing.Type[typing.Any]: ...
 def _type_matching(actual: typing.Type[typing.Any], expected: typing.Type[typing.Any]) -> bool: ...
+def _handle_callable_arg(
+    attribute: attr.Attribute[typing.Any],
+    _signature: inspect.Signature,
+    expected_type: typing.Type[typing.Callable[..., typing.Any]],
+    actual: typing.Type[typing.Any],
+    expected: typing.Type[typing.Any],
+) -> None: ...
 def _handle_callable(
     attribute: attr.Attribute[typing.Any],
     callable_: typing.Callable[..., typing.Any],

--- a/tests/test_callable.py
+++ b/tests/test_callable.py
@@ -24,6 +24,11 @@ class _TestResources:
 
     int_int_returns_str.__annotations__ = {"a": int, "b": int, "return": str}
 
+    def int_int_returns_none(a, b):
+        pass
+
+    int_int_returns_none.__annotations__ = {"a": int, "b": int, "return": None}
+
     def newint_int_returns_str(a, b):
         pass
 
@@ -108,6 +113,11 @@ class _TestResources:
             typing.Callable[[int, int], str],
         ),
         (
+            "typed_callable_none",
+            _TestResources.int_int_returns_none,
+            typing.Callable[[int, int], None],
+        ),
+        (
             "list_of_typed_callables",
             [_TestResources.int_int_returns_str] * 3,
             typing.List[typing.Callable[[int, int], str]],
@@ -161,6 +171,11 @@ class _TestResources:
         (
             "any_type_str_provided",
             _TestResources.int_int_returns_str,
+            typing.Callable[[int, int], typing.Any],
+        ),
+        (
+            "any_type_none_provided",
+            _TestResources.int_int_returns_none,
             typing.Callable[[int, int], typing.Any],
         ),
         (

--- a/tests/test_callable.py
+++ b/tests/test_callable.py
@@ -29,6 +29,15 @@ class _TestResources:
 
     int_int_returns_none.__annotations__ = {"a": int, "b": int, "return": None}
 
+    def int_default_int_returns_str(a, b=1):
+        pass
+
+    int_default_int_returns_str.__annotations__ = {
+        "a": int,
+        "b": int,
+        "return": str,
+    }
+
     def newint_int_returns_str(a, b):
         pass
 
@@ -116,6 +125,16 @@ class _TestResources:
             "typed_callable_none",
             _TestResources.int_int_returns_none,
             typing.Callable[[int, int], None],
+        ),
+        (
+            "typed_callable_default_missing",
+            _TestResources.int_default_int_returns_str,
+            typing.Callable[[int], str],
+        ),
+        (
+            "typed_callable_default_present",
+            _TestResources.int_default_int_returns_str,
+            typing.Callable[[int, int], str],
         ),
         (
             "list_of_typed_callables",
@@ -209,6 +228,12 @@ def test_callable_not_raises_with_valid_annotations(
             "callable_with_incorrect_types",
             _TestResources.int_int_returns_int,
             typing.Callable[[int, int], str],
+            CallableError,
+        ),
+        (
+            "callable_with_incorrect_default_types",
+            _TestResources.int_default_int_returns_str,
+            typing.Callable[[int, str], str],
             CallableError,
         ),
         (

--- a/tests/test_callable.py
+++ b/tests/test_callable.py
@@ -24,6 +24,11 @@ class _TestResources:
 
     int_int_returns_str.__annotations__ = {"a": int, "b": int, "return": str}
 
+    def no_args_returns_str():
+        pass
+
+    no_args_returns_str.__annotations__ = {"return": str}
+
     def int_int_returns_none(a, b):
         pass
 
@@ -33,6 +38,24 @@ class _TestResources:
         pass
 
     int_default_int_returns_str.__annotations__ = {
+        "a": int,
+        "b": int,
+        "return": str,
+    }
+
+    def int_default_kwonly_int_returns_str(a, *, b=1):
+        pass
+
+    int_default_kwonly_int_returns_str.__annotations__ = {
+        "a": int,
+        "b": int,
+        "return": str,
+    }
+
+    def int_kwonly_int_returns_str(a, *, b):
+        pass
+
+    int_kwonly_int_returns_str.__annotations__ = {
         "a": int,
         "b": int,
         "return": str,
@@ -122,6 +145,11 @@ class _TestResources:
             typing.Callable[[int, int], str],
         ),
         (
+            "typed_callable_no_args",
+            _TestResources.no_args_returns_str,
+            typing.Callable[[], str],
+        ),
+        (
             "typed_callable_none",
             _TestResources.int_int_returns_none,
             typing.Callable[[int, int], None],
@@ -135,6 +163,11 @@ class _TestResources:
             "typed_callable_default_present",
             _TestResources.int_default_int_returns_str,
             typing.Callable[[int, int], str],
+        ),
+        (
+            "typed_callable_kwonly_default_missing",
+            _TestResources.int_default_kwonly_int_returns_str,
+            typing.Callable[[int], str],
         ),
         (
             "list_of_typed_callables",
@@ -225,6 +258,18 @@ def test_callable_not_raises_with_valid_annotations(
             AttributeTypeError,
         ),
         (
+            "callable_with_not_enough_types",
+            _TestResources.int_int_returns_int,
+            typing.Callable[[int, int, int], str],
+            CallableError,
+        ),
+        (
+            "callable_with_too_many_types",
+            _TestResources.int_int_returns_int,
+            typing.Callable[[int], str],
+            CallableError,
+        ),
+        (
             "callable_with_incorrect_types",
             _TestResources.int_int_returns_int,
             typing.Callable[[int, int], str],
@@ -234,6 +279,24 @@ def test_callable_not_raises_with_valid_annotations(
             "callable_with_incorrect_default_types",
             _TestResources.int_default_int_returns_str,
             typing.Callable[[int, str], str],
+            CallableError,
+        ),
+        (
+            "callable_with_provided_default_kwonly_types",
+            _TestResources.int_default_kwonly_int_returns_str,
+            typing.Callable[[int, int], str],
+            CallableError,
+        ),
+        (
+            "callable_with_missing_kwonly_types",
+            _TestResources.int_kwonly_int_returns_str,
+            typing.Callable[[int], str],
+            CallableError,
+        ),
+        (
+            "callable_with_provided_kwonly_types",
+            _TestResources.int_kwonly_int_returns_str,
+            typing.Callable[[int, int], str],
             CallableError,
         ),
         (

--- a/tests/test_callable__py3.py
+++ b/tests/test_callable__py3.py
@@ -1,15 +1,9 @@
-import sys
 import typing
 
 import attr
 import pytest
 
 from attrs_strict import AttributeTypeError, CallableError, type_validator
-
-not_on_py2 = pytest.mark.xfail(
-    sys.version_info < (3, 5),
-    reason="Type annotations for callables are not supported in py2",
-)
 
 
 class _TestResources:
@@ -110,7 +104,6 @@ class _TestResources:
     int_default_returns_int.__annotations__ = {"a": int, "return": int}
 
 
-@not_on_py2
 @pytest.mark.parametrize(
     "name, callable_, attribute_type",
     [
@@ -247,7 +240,6 @@ def test_callable_not_raises_with_valid_annotations(
     Something(call_me=callable_)
 
 
-@not_on_py2
 @pytest.mark.parametrize(
     "name, callable_, attribute_type, raised_error_type",
     [


### PR DESCRIPTION
## Describe your changes

This PR fixes some false positive errors with `Callable` types.

1) According to [PEP 484](https://www.python.org/dev/peps/pep-0484/#using-none) "When used in a type hint, the expression `None` is considered equivalent to `type(None)`." Currently, this is not the case for return values of `Callable` type hints.

    This leads to "funny" error messages like this:
    ```python
    attrs_strict._error.CallableError: Error with: call_me . Expected Callable signature: typing.Callable[[int, int], NoneType] got: 
    (a:int, b:int) -> None. None should be <class 'NoneType'>
    ```
    from
    ```python
    expected = Callable[[int, int], None]
    def call_me(a:int, b:int) -> None:
        pass
    ```

2) Functions with default values for arguments weren't handled properly.<br/>
    With this PR, the following function
    ```python
    def foo(a: int, b: int = 123) -> str: ...
    ```
    will also satisfy `Callable[[int], str]` and not just `Callable[[int, int], str]`.

3) Functions with keyword-only arguments weren't handled properly.<br/>
    With this PR,
    ```python
    def foo1(a: int, *, b: int = 123) -> str: ...
    def foo2(a: int, *, b: int) -> str: ...
    ```
     `foo1` will satisfy `Callable[[int], str]` but not `Callable[[int, int], str]`.
     `foo2` won't satisfy any of the above signatures (since `Callable` is positional-only).

## Testing performed

I added test cases for each item in "Describe your changes" (both false positives and false negatives).