### PR TITLE
Support added for Python3.10's Union Pipe operator

### DIFF
--- a/src/attrs_strict/_type_validation.py
+++ b/src/attrs_strict/_type_validation.py
@@ -4,12 +4,15 @@ import collections
 import inspect
 import sys
 import typing
-import types
 from collections.abc import Callable, Mapping, MutableMapping
 from enum import Enum
 from inspect import Parameter, Signature, signature
 from itertools import zip_longest
 from typing import ForwardRef
+
+if sys.version_info >= (3, 10):
+    from types import UnionType
+
 if sys.version_info >= (3, 8):  # pragma: >=3.8 cover
     from typing import Literal
 else:  # pragma: <3.8 cover
@@ -127,7 +130,7 @@ def _validate_elements(
         raise _StringAnnotationError()
     elif base_type == Literal or base_type == type(Literal):  # type: ignore
         _handle_literal(attribute, value, expected_type)
-    elif base_type == typing.Union or base_type == types.UnionType:  # type: ignore
+    elif base_type == typing.Union or (sys.version_info >= (3, 10) and base_type == UnionType):  # type: ignore
         _handle_union(attribute, value, expected_type)
     elif not isinstance(value, base_type):
         raise AttributeTypeError(value, attribute)
@@ -166,7 +169,7 @@ def _type_matching(
 
     base_type = _get_base_type(expected)
 
-    if base_type == typing.Union or base_type == types.UnionType:  # type: ignore
+    if base_type == typing.Union or (sys.version_info >= (3, 10) and base_type == UnionType):  # type: ignore
         return any(
             _type_matching(actual, expected_candidate)
             for expected_candidate in expected.__args__

--- a/src/attrs_strict/_type_validation.py
+++ b/src/attrs_strict/_type_validation.py
@@ -4,12 +4,12 @@ import collections
 import inspect
 import sys
 import typing
+import types
 from collections.abc import Callable, Mapping, MutableMapping
 from enum import Enum
 from inspect import Parameter, Signature, signature
 from itertools import zip_longest
 from typing import ForwardRef
-
 if sys.version_info >= (3, 8):  # pragma: >=3.8 cover
     from typing import Literal
 else:  # pragma: <3.8 cover
@@ -127,7 +127,7 @@ def _validate_elements(
         raise _StringAnnotationError()
     elif base_type == Literal or base_type == type(Literal):  # type: ignore
         _handle_literal(attribute, value, expected_type)
-    elif base_type == typing.Union:  # type: ignore
+    elif base_type == typing.Union or base_type == types.UnionType:  # type: ignore
         _handle_union(attribute, value, expected_type)
     elif not isinstance(value, base_type):
         raise AttributeTypeError(value, attribute)
@@ -166,7 +166,7 @@ def _type_matching(
 
     base_type = _get_base_type(expected)
 
-    if base_type == typing.Union:  # type: ignore
+    if base_type == typing.Union or base_type == types.UnionType:  # type: ignore
         return any(
             _type_matching(actual, expected_candidate)
             for expected_candidate in expected.__args__

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -29,6 +29,15 @@ from attrs_strict import type_validator
                 )
             ),
         ),
+        (
+            10,
+            str | None if sys.version_info >= (3, 10) else Union[str, None],
+            "Value of foo 10 is not of type {}".format(
+                "str | None"
+                if sys.version_info >= (3, 10)
+                else "typing.Optional[str]"
+            ),
+        ),
     ],
 )
 def test_union_when_type_is_not_specified_raises(element, type_, error_message):
@@ -48,6 +57,9 @@ def test_union_when_type_is_not_specified_raises(element, type_, error_message):
         (2.0, Union[int, float]),
         ([1, 2, None, 4, 5], List[Union[None, int]]),
         (None, Union[int, None]),
+        (10, int | None)
+        if sys.version_info >= (3, 10)
+        else (10, Union[int, None]),
     ],
 )
 def test_union_not_raise_for_correct_values(element, type_):


### PR DESCRIPTION
**Issue number of the reported bug or feature request:**
Issue #80 

**Describe your changes**
This PR is based on the PR https://github.com/bloomberg/attrs-strict/pull/102 because of permission issues.

In order to resolve the issue - Support of pipe symbol for Union operation. Python3.10 uses base type as types.UnionTypes. So therefore added a case for that (If the base type is types.UnionTypes then perform validation). Hence supporting Union as X | Y.


**Testing performed**
Testing performed on Mac OS 13.3.1 and Python 3.10.7

**Additional context**
Add any other context about your contribution here.
