### PR TITLE
fix: support types without args

### DIFF
--- a/src/attrs_strict/_type_validation.py
+++ b/src/attrs_strict/_type_validation.py
@@ -310,7 +310,7 @@ def _handle_tuple(
 ) -> None:
     tuple_types = get_args(expected_type)
 
-    if not tuple_types :
+    if not tuple_types:
         return  # No annotations specified on type, matches all tuples
 
     if len(tuple_types) == 2 and tuple_types[1] == Ellipsis:

--- a/src/attrs_strict/_type_validation.py
+++ b/src/attrs_strict/_type_validation.py
@@ -268,7 +268,7 @@ def _handle_set_or_list(
     if not hasattr(expected_type, "__args__"):
         return  # No annotations specified on type, matches all sets or lists
 
-    (element_type,) = expected_type.__args__  # type: ignore
+    (element_type,) = expected_type.__args__
 
     for element in container:
         try:
@@ -288,7 +288,7 @@ def _handle_dict(
     if not hasattr(expected_type, "__args__"):
         return  # No annotations specified on type, matches all dicts
 
-    key_type, value_type = expected_type.__args__  # type: ignore
+    key_type, value_type = expected_type.__args__
 
     for key in container:
         try:

--- a/src/attrs_strict/_type_validation.py
+++ b/src/attrs_strict/_type_validation.py
@@ -265,6 +265,9 @@ def _handle_set_or_list(
     container: set[typing.Any] | list[typing.Any],
     expected_type: type[set[typing.Any]] | type[list[typing.Any]],
 ) -> None:
+    if not hasattr(expected_type, '__args__'):
+        return  # No annotations specified on type, matches all sets or lists
+
     (element_type,) = expected_type.__args__  # type: ignore
 
     for element in container:

--- a/src/attrs_strict/_type_validation.py
+++ b/src/attrs_strict/_type_validation.py
@@ -304,6 +304,9 @@ def _handle_tuple(
     container: tuple[typing.Any],
     expected_type: type[tuple[typing.Any]],
 ) -> None:
+    if not hasattr(expected_type, "__args__"):
+        return  # No annotations specified on type, matches all tuples
+
     tuple_types = expected_type.__args__  # type: ignore
     if len(tuple_types) == 2 and tuple_types[1] == Ellipsis:
         element_type = tuple_types[0]

--- a/src/attrs_strict/_type_validation.py
+++ b/src/attrs_strict/_type_validation.py
@@ -265,7 +265,7 @@ def _handle_set_or_list(
     container: set[typing.Any] | list[typing.Any],
     expected_type: type[set[typing.Any]] | type[list[typing.Any]],
 ) -> None:
-    if not hasattr(expected_type, '__args__'):
+    if not hasattr(expected_type, "__args__"):
         return  # No annotations specified on type, matches all sets or lists
 
     (element_type,) = expected_type.__args__  # type: ignore
@@ -285,7 +285,7 @@ def _handle_dict(
     expected_type: type[typing.Mapping[typing.Any, typing.Any]]
     | type[typing.MutableMapping[typing.Any, typing.Any]],
 ) -> None:
-    if not hasattr(expected_type, '__args__'):
+    if not hasattr(expected_type, "__args__"):
         return  # No annotations specified on type, matches all dicts
 
     key_type, value_type = expected_type.__args__  # type: ignore

--- a/src/attrs_strict/_type_validation.py
+++ b/src/attrs_strict/_type_validation.py
@@ -285,6 +285,9 @@ def _handle_dict(
     expected_type: type[typing.Mapping[typing.Any, typing.Any]]
     | type[typing.MutableMapping[typing.Any, typing.Any]],
 ) -> None:
+    if not hasattr(expected_type, '__args__'):
+        return  # No annotations specified on type, matches all dicts
+
     key_type, value_type = expected_type.__args__  # type: ignore
 
     for key in container:

--- a/src/attrs_strict/_type_validation.py
+++ b/src/attrs_strict/_type_validation.py
@@ -14,9 +14,9 @@ if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
     from types import UnionType
 
 if sys.version_info >= (3, 8):  # pragma: >=3.8 cover
-    from typing import Literal
+    from typing import Literal, get_args
 else:  # pragma: <3.8 cover
-    from typing_extensions import Literal
+    from typing_extensions import Literal, get_args
 
 import attr
 
@@ -265,10 +265,12 @@ def _handle_set_or_list(
     container: set[typing.Any] | list[typing.Any],
     expected_type: type[set[typing.Any]] | type[list[typing.Any]],
 ) -> None:
-    if not hasattr(expected_type, "__args__"):
+    args = get_args(expected_type)
+
+    if not args:
         return  # No annotations specified on type, matches all sets or lists
 
-    (element_type,) = expected_type.__args__
+    (element_type,) = args
 
     for element in container:
         try:
@@ -285,10 +287,12 @@ def _handle_dict(
     expected_type: type[typing.Mapping[typing.Any, typing.Any]]
     | type[typing.MutableMapping[typing.Any, typing.Any]],
 ) -> None:
-    if not hasattr(expected_type, "__args__"):
+    args = get_args(expected_type)
+
+    if not args:
         return  # No annotations specified on type, matches all dicts
 
-    key_type, value_type = expected_type.__args__
+    key_type, value_type = args
 
     for key in container:
         try:
@@ -304,10 +308,11 @@ def _handle_tuple(
     container: tuple[typing.Any],
     expected_type: type[tuple[typing.Any]],
 ) -> None:
-    if not hasattr(expected_type, "__args__"):
+    tuple_types = get_args(expected_type)
+
+    if not tuple_types :
         return  # No annotations specified on type, matches all tuples
 
-    tuple_types = expected_type.__args__  # type: ignore
     if len(tuple_types) == 2 and tuple_types[1] == Ellipsis:
         element_type = tuple_types[0]
         tuple_types = (element_type,) * len(container)

--- a/tests/test_callable__py3.py
+++ b/tests/test_callable__py3.py
@@ -229,6 +229,11 @@ class _TestResources:
             _TestResources.int_default_returns_int,
             typing.Callable[[int], int],
         ),
+        (
+                "callable_with_no_args",
+                _TestResources.plain_unannotated_callable,
+                typing.Callable,
+        ),
     ],
 )
 def test_callable_not_raises_with_valid_annotations(

--- a/tests/test_callable__py3.py
+++ b/tests/test_callable__py3.py
@@ -230,9 +230,9 @@ class _TestResources:
             typing.Callable[[int], int],
         ),
         (
-                "callable_with_no_args",
-                _TestResources.plain_unannotated_callable,
-                typing.Callable,
+            "callable_with_no_args",
+            _TestResources.plain_unannotated_callable,
+            typing.Callable,
         ),
     ],
 )

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -51,9 +51,9 @@ def test_defaultdict_with_correct_type_no_raise():
     [
         ({}, dict),
         ({}, Dict),
-        ({'a': 1}, dict),
-        ({'a': 1}, Dict),
-    ]
+        ({"a": 1}, dict),
+        ({"a": 1}, Dict),
+    ],
 )
 def test_dict_without_args_any_does_not_raise(data, type):
     validator = type_validator()

--- a/tests/test_dict.py
+++ b/tests/test_dict.py
@@ -46,6 +46,25 @@ def test_defaultdict_with_correct_type_no_raise():
     validator(None, attr, elem)
 
 
+@pytest.mark.parametrize(
+    ("data", "type"),
+    [
+        ({}, dict),
+        ({}, Dict),
+        ({'a': 1}, dict),
+        ({'a': 1}, Dict),
+    ]
+)
+def test_dict_without_args_any_does_not_raise(data, type):
+    validator = type_validator()
+
+    attr = MagicMock()
+    attr.name = "zoo"
+    attr.type = type
+
+    validator(None, attr, data)
+
+
 def test_dict_with_any_does_not_raise():
     elem = {"foo": 123, "b": "abc"}
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -76,6 +76,8 @@ def test_list_of_values_raise_value_error(values, type_, error_message):
         ([{1: [1, 2, 3], 2: [3, 4, 5]}], List[Dict[int, List[int]]]),
         ([1, 2, 3, 4], List[Any]),
         ([1, 2, {"foo": "bar"}], List[Any]),
+        ([1, '2', 3.5], list),
+        ([1, '2', 3.5], List),
     ],
 )
 def test_list_of_valid_values_no_raise(values, type_):

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -76,8 +76,8 @@ def test_list_of_values_raise_value_error(values, type_, error_message):
         ([{1: [1, 2, 3], 2: [3, 4, 5]}], List[Dict[int, List[int]]]),
         ([1, 2, 3, 4], List[Any]),
         ([1, 2, {"foo": "bar"}], List[Any]),
-        ([1, '2', 3.5], list),
-        ([1, '2', 3.5], List),
+        ([1, "2", 3.5], list),
+        ([1, "2", 3.5], List),
     ],
 )
 def test_list_of_valid_values_no_raise(values, type_):

--- a/tests/test_tuple.py
+++ b/tests/test_tuple.py
@@ -68,6 +68,23 @@ def test_variable_length_tuple_empty():
     validator(None, attr, element)
 
 
+@pytest.mark.parametrize(
+    ("data", "type"),
+    [
+        ((1, 2, 3), tuple),
+        ((1, 2, 3), Tuple),
+    ],
+)
+def test_tuple_without_args(data, type):
+    attr = MagicMock()
+    attr.name = "foo"
+    attr.type = type
+
+    validator = type_validator()
+
+    validator(None, attr, data)
+
+
 def test_variable_length_tuple_raises():
     element = (1, 2, 3, "4")
 


### PR DESCRIPTION
Issue number of the reported bug or feature request: no related issue.

**Describe your changes**
The validator was not supporting types without args. For example: 

```python
>>> from unittest.mock import MagicMock
>>> from attrs_strict import type_validator
>>>
>>> attr = MagicMock()
>>> attr.name = "zoo"
>>> attr.type = list
>>>
>>> type_validator()(None, attr, [1, 2, 3])
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
...
AttributeError: type object 'list' has no attribute '__args__'
````

This PR fixes it for lists, dicts, and tuples.


**Testing performed**
Written tests.