### PR TITLE
Fix testing on python 3.14

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -66,16 +66,13 @@ jobs:
         run: tox -vv --notest
       - name: run test suite for ${{ matrix.py }}
         run: tox --skip-pkg-install
-      - name: Rename coverage report file
-        run: |
-          import os; import sys
-          os.rename(f".tox/.coverage.{os.environ['TOXENV']}", f".tox/.coverage.{os.environ['TOXENV']}-{sys.platform}")
-        shell: python
       - name: Upload coverage data
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-data
+          name: coverage-data-${{ matrix.py }}
           path: ".tox/.coverage.*"
+          include-hidden-files: true
+          overwrite: true
 
   coverage:
     name: Combine coverage
@@ -99,7 +96,8 @@ jobs:
       - name: Download coverage data
         uses: actions/download-artifact@v7
         with:
-          name: coverage-data
+          pattern: coverage-data-*
+          merge-multiple: true
           path: .tox
       - name: Combine and report coverage
         run: tox -e coverage

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
   lint:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -40,7 +40,7 @@ jobs:
           - "pypy-3.8"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: setup python for tox
         uses: actions/setup-python@v5
         with:
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v5
@@ -118,7 +118,7 @@ jobs:
           - docs
           - type
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: setup Python "3.12"
         uses: actions/setup-python@v5
         with:
@@ -139,7 +139,7 @@ jobs:
           python-version: "3.12"
       - name: install build
         run: python -m pip install build
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: build package
         run: python -m build --sdist --wheel . -o dist
       - name: publish to PyPi

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -70,7 +70,7 @@ jobs:
           os.rename(f".tox/.coverage.{os.environ['TOXENV']}", f".tox/.coverage.{os.environ['TOXENV']}-{sys.platform}")
         shell: python
       - name: Upload coverage data
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-data
           path: ".tox/.coverage.*"
@@ -102,7 +102,7 @@ jobs:
       - name: Combine and report coverage
         run: tox -e coverage
       - name: Upload HTML report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: html-report
           path: .tox/htmlcov

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
       - uses: pre-commit/action@v3.0.1
@@ -44,13 +44,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: setup python for tox
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
       - name: install tox
         run: python -m pip install tox
       - name: setup python for test ${{ matrix.py }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: ${{ matrix.py }}
       - name: Pick environment to run
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
       - name: Install tox
@@ -122,7 +122,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: setup Python "3.12"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
       - name: install tox
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: setup python to build package
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.12"
       - name: install build

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,6 +30,8 @@ jobs:
       fail-fast: false
       matrix:
         py:
+          - "3.14"
+          - "3.13"
           - "3.12"
           - "3.11"
           - "3.10"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Build package
         run: pyproject-build --wheel .
       - name: Download coverage data
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v7
         with:
           name: coverage-data
           path: .tox

--- a/tests/test_auto_attribs__py3.py
+++ b/tests/test_auto_attribs__py3.py
@@ -28,9 +28,13 @@ from attrs_strict import type_validator
             None,
             0xBAD,
             "Value of value 2989 is not of type {}".format(
-                "typing.Optional[str]"
-                if sys.version_info == (2, 7) or sys.version_info > (3, 9)
-                else "typing.Union[str, NoneType]"
+                "str | None"
+                if sys.version_info >= (3, 14)
+                else (
+                    "typing.Optional[str]"
+                    if sys.version_info == (2, 7) or sys.version_info > (3, 9)
+                    else "typing.Union[str, NoneType]"
+                )
             ),
         ),
     ],
@@ -75,9 +79,13 @@ def test_recursive():
     Self(Self())
     Self(Self(None))
     type_repr = (
-        "typing.Optional[test_auto_attribs__py3.Self]"
-        if sys.version_info == (2, 7) or sys.version_info > (3, 9)
-        else "typing.Union[test_auto_attribs__py3.Self, NoneType]"
+        "test_auto_attribs__py3.Self | None"
+        if sys.version_info >= (3, 14)
+        else (
+            "typing.Optional[test_auto_attribs__py3.Self]"
+            if sys.version_info == (2, 7) or sys.version_info > (3, 9)
+            else "typing.Union[test_auto_attribs__py3.Self, NoneType]"
+        )
     )
     msg = f"Value of parent 17 is not of type {type_repr}"
     with pytest.raises(ValueError, match=re.escape(msg)):

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -16,16 +16,26 @@ from attrs_strict import type_validator
         (
             2.0,
             Union[int, str],
-            "Value of foo 2.0 is not of type typing.Union[int, str]",
+            (
+                "Value of foo 2.0 is not of type {}".format(
+                    "int | str"
+                    if sys.version_info >= (3, 14)
+                    else "typing.Union[int, str]"
+                )
+            ),
         ),
         (
             [1, 2, "p"],
             List[Union[None, int]],
             (
                 "Value of foo p is not of type {} in [1, 2, 'p']".format(
-                    "typing.Optional[int]"
-                    if sys.version_info >= (3, 9)
-                    else "typing.Union[NoneType, int]"
+                    "None | int"
+                    if sys.version_info >= (3, 14)
+                    else (
+                        "typing.Optional[int]"
+                        if sys.version_info >= (3, 9)
+                        else "typing.Union[NoneType, int]"
+                    )
                 )
             ),
         ),


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
While debugging build failures on nixpkgs https://hydra.nixos.org/build/324623391/nixlog/3
I found out stringifying types changed on Python 3.14 this PR adjusts the expected error messages on the testing side.


**Testing performed**
Run CI.

**Additional context**
While running CI I found that {upload,download}-artifact is deprecated
https://github.com/applePrincess/attrs-strict/actions/runs/24253561877/job/70819921414
So update actions.
Also add python 3.13 and 3.14 running CI.